### PR TITLE
users/my api 구현

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,35 @@
+const jwtUtil = require('../utils/jwt'); 
+const userStore = require('../store/userStore');
+const errorMessage = require('../utils/errorMessage'); 
+
+exports.getMyProfile = async (req, res) => {
+  try {
+    const token = req.headers['authorization'];
+    if (!token) {
+      return errorMessage(res, 401); 
+    }
+
+    const tokenValue = token.split(' ')[1];
+    if (!tokenValue) {
+      return errorMessage(res, 401); 
+    }
+
+    const authorization = jwtUtil.verifyToken(tokenValue);
+    if (!authorization || !authorization.id) {
+      return errorMessage(res, 401); 
+    }
+
+    const userId = authorization.id;
+
+    const user = await userStore.findById(userId);
+    if (!user) {
+      return errorMessage(res, 404); 
+    }
+
+    return res.status(200).json(user); 
+
+  } catch (error) {
+    console.error('Error fetching user profile:', error);
+    return errorMessage(res, 500); 
+  }
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 const authController = require('../controllers/authController');
-
+const userController = require('../controllers/userController');
 /**
  *  @swagger
  *    paths:
@@ -164,4 +164,5 @@ router.get('/test', (req, res) => {
 
     res.json(testData);  // JSON 형식으로 응답
 });
+router.get('/my', userController.getMyProfile);
 module.exports = router;

--- a/store/userStore.js
+++ b/store/userStore.js
@@ -35,6 +35,11 @@ class UserStore {
     const [rows] = await db.execute(query, queryParams);
     return rows;
   }
+  // 사용자 ID로 조회 (추가된 부분)
+  async findById(userId) {
+    const [rows] = await db.execute('SELECT * FROM users WHERE id = ?', [userId]);
+    return rows[0];
+  }
 }
 
 module.exports = new UserStore();

--- a/utils/errorMessage.js
+++ b/utils/errorMessage.js
@@ -6,7 +6,7 @@ const errorMessage = (res, statusCode) => {
         message: "요청 파라미터가 잘못되었습니다."
       });
     case 401:
-      res.status(401).json({
+      return res.status(401).json({
         "errorCode": "UNAUTHORIZED",
         "message": "회원 인증이 필요합니다."
       });


### PR DESCRIPTION
GET /users/my 엔드포인트 구현했습니다.

Authorization 헤더에 포함된 JWT 토큰을 사용하여 유저 정보를 조회하고,
유효하지 않은 토큰이나 누락된 토큰에 대해 적절한 오류 응답 처리 (401, 404, 500 상태 코드)
유저 정보가 존재할 경우 성공적인 응답 (200 상태 코드)

사용자가 자신의 프로필 정보를 조회할 수 있는 기능을 구현하기 위해 JWT 인증을 기반으로 유저 정보를 반환하도록 설정했습니다.

JWT 토큰을 헤더에 포함시켜 /users/my API에 요청을 보낼 때 올바른 응답을 받는지 확인하고,
유효하지 않은 토큰, 누락된 토큰, 유저 정보가 없는 경우의 오류 처리 검증했습니다.